### PR TITLE
Add compiler sanitizer options

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ./autogen.sh || exit 1
-./configure || exit 1
+./configure --enable-gcc-warnings || exit 1
 make -j3 || exit 1
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
   make install || exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,8 @@ if test "$gl_gcc_warnings" = yes; then
     gl_WARN_ADD([$w])
   done
   gl_WARN_ADD([-fdiagnostics-show-option])
+  gl_WARN_ADD([-fsanitize=undefined])
+  gl_WARN_ADD([-fno-sanitize-recover=undefined])
   gl_WARN_ADD([-Wno-missing-field-initializers]) # Rely on missing field = 0.
   AC_SUBST([WARN_CFLAGS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,8 @@ if test "$gl_gcc_warnings" = yes; then
   done
   gl_WARN_ADD([-fdiagnostics-show-option])
   gl_WARN_ADD([-fsanitize=undefined])
+  gl_WARN_ADD([-fsanitize=address])
+  gl_WARN_ADD([-fno-omit-frame-pointer])
   gl_WARN_ADD([-fno-sanitize-recover=undefined])
   gl_WARN_ADD([-Wno-missing-field-initializers]) # Rely on missing field = 0.
   AC_SUBST([WARN_CFLAGS])

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -866,7 +866,7 @@ void wget_test(int first_key, ...)
 				wget_error_printf_exit(_("Missing expected file %s/%s [%s]\n"), tmpdir, expected_files[it].name, options);
 
 			if (expected_files[it].content) {
-				char content[st.st_size];
+				char content[st.st_size ? st.st_size : 1];
 
 				if ((fd = open(expected_files[it].name, O_RDONLY)) != -1) {
 					ssize_t nbytes = read(fd, content, st.st_size);


### PR DESCRIPTION
Add some compiler sanitizer options which detect issues at runtime. There's a few caveats:

1. I've added the compiler flags to the standard gcc warnings configure option. We should move this to a different option (like --maintainer-mode), since these options add instrumentation instructions that causes considerable runtime overhead. It is possible that someone way compile Wget2 with gcc warnings enabled without realizing that it includes these options that cause a performance overhead as well

2. They don't seem to work on Travis very well. The version of GCC on travis is too old to support these options. And on travis using clang, these options are not enabled through the configure script at all. 